### PR TITLE
Add signature to methodHelp, sort listMethods

### DIFF
--- a/flask_fastrpc.py
+++ b/flask_fastrpc.py
@@ -166,7 +166,7 @@ class FastRPCHandler:
         """
         Return list of all available FastRPC methods.
         """
-        return list(self.methods.keys())
+        return sorted(list(self.methods.keys()))
 
     def _system_method_help(self, method_name: str) -> str:
         """
@@ -174,10 +174,11 @@ class FastRPCHandler:
         """
         try:
             func = self.methods[method_name]
-            doc = inspect.getdoc(func)
-            return doc if doc else ''
         except KeyError:
             raise Exception("Method '%s' doesn't exist" % method_name)
+        signature = method_name + str(inspect.signature(func))
+        doc = inspect.getdoc(func) or ''
+        return "{}\n\n{}".format(signature, doc)
 
     def stat(self):
         """Basic method returning status 200"""


### PR DESCRIPTION
Method signature is important part of method documentation. It's not part of docstrings as user usually sees it when browsing code, but its super helpful for RPC method help.
Sorted listMethods output for easier navigation